### PR TITLE
Fix plotly version to 5.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 streamlit==1.37.0
 pandas==2.3.2
 numpy==1.26.4
-plotly==6.3.0
+plotly>=5,<6


### PR DESCRIPTION
## Summary
- use plotly 5.x instead of unavailable plotly 6.3.0

## Testing
- `pip install -r requirements.txt` (fails: Cannot connect to proxy)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acd08ca48c8323a6cda663140a8f56