### PR TITLE
Fix manufacturing duration backfill when committed delivery is set

### DIFF
--- a/Procurement_Calculator.py
+++ b/Procurement_Calculator.py
@@ -136,7 +136,17 @@ def compute_all(df: pd.DataFrame, holiday_set) -> pd.DataFrame:
         buf = as_int(row.get("Buffer (days)"), DEFAULT_BUFFER_DAYS)
 
         # Derive Manufacturing (days) if committed delivery is present (Forward)
-        if mode == "Forward" and pd.notna(committed_delivery) and (pd.isna(mfg) or mfg == "") and pd.notna(po):
+        def _needs_mfg_calc(val):
+            if pd.isna(val):
+                return True
+            if isinstance(val, str) and val.strip() == "":
+                return True
+            try:
+                return float(val) == 0.0
+            except Exception:
+                return False
+
+        if mode == "Forward" and pd.notna(committed_delivery) and _needs_mfg_calc(mfg) and pd.notna(po):
             mfg_end = bday_sub(committed_delivery, buf, holiday_set)
             mfg_end = bday_sub(mfg_end, ship, holiday_set)
             sub_end = bday_add(po, sub, holiday_set)


### PR DESCRIPTION
## Summary
- update the auto-calculation guard so blank or zero manufacturing durations are recomputed when a committed delivery is present
- keep the forward-pass workflow deriving manufacturing spans once PO execution and committed delivery are set

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e6cf69d328832382688f27a169bf30